### PR TITLE
Remove push triggers from test workflows

### DIFF
--- a/.github/workflows/test-data-processing.yml
+++ b/.github/workflows/test-data-processing.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-  push:
-    branches-ignore:
-      - main
 
 jobs:
   test_data_processing:

--- a/.github/workflows/test-make-mc-manifest.yml
+++ b/.github/workflows/test-make-mc-manifest.yml
@@ -5,9 +5,6 @@ on:
         branches:
             - main
 
-    push:
-        branches-ignore:
-            - main
 
 jobs:
     test_make_mc_manifest:

--- a/.github/workflows/test-mutation-calling.yml
+++ b/.github/workflows/test-mutation-calling.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-  push:
-    branches-ignore:
-      - main
 
 jobs:
   test_mutation_calling:


### PR DESCRIPTION
Tests now only run on pull requests to main, not on every push to non-main branches.