### PR TITLE
Simplify fingerprint BAM channel to cnvkit-style ID parsing

### DIFF
--- a/nextflow_automation/fingerprint/fingerprint.nf
+++ b/nextflow_automation/fingerprint/fingerprint.nf
@@ -1,0 +1,97 @@
+nextflow.enable.dsl = 2
+
+// import modules
+include { EXTRACT_FINGERPRINT } from './modules/extract_fingerprint.nf'
+include { CROSSCHECK_FINGERPRINTS } from './modules/crosscheck_fingerprints.nf'
+
+
+// main workflow
+workflow FINGERPRINT {
+    // Show help message if requested
+    if (params.help) {
+        help = """Usage:
+
+        The typical command for running the pipeline is as follows:
+
+        nextflow -C <CONFIG_FILE> run fingerprint.nf --bam_dir <PATH> --output_dir <PATH> --ref_dir <PATH> --haplotype_map <FILE> [OPTIONS]
+
+        Required arguments:
+        --bam_dir                     Path to the directory containing input BAM files
+        --output_dir                  Path to the output directory to publish results
+        --ref_dir                     Path to the reference directory
+        --haplotype_map               File name of the haplotype map inside ref_dir (eg: hg38_chr1-22XY.map)
+
+        Optional arguments:
+        --cpus                        Number of CPUs to use for processing (default: 4)
+        --help                        Show this help message and exit
+        """
+
+        // Print the help and exit
+        println(help)
+        exit(0)
+    }
+
+    // Parameter validation
+    if (!params.bam_dir) {
+        error "ERROR: --bam_dir parameter is required"
+        exit 1
+    }
+
+    if (!params.output_dir) {
+        error "ERROR: --output_dir parameter is required"
+        exit 1
+    }
+
+    if (!params.ref_dir) {
+        error "ERROR: --ref_dir parameter is required"
+        exit 1
+    }
+
+    if (!params.haplotype_map) {
+        error "ERROR: --haplotype_map parameter is required"
+        exit 1
+    }
+
+    // workflow logging
+    log.info """\
+ __     __     ______     ______     __         ______     __  __
+/\\ \\  _ \\ \\   /\\  ___\\   /\\  ___\\   /\\ \\       /\\  ___\\   /\\ \\_\\ \\
+\\ \\ \\/ ".\\ \\  \\ \\  __\\   \\ \\___  \\  \\ \\ \\____  \\ \\  __\\   \\ \\____ \\
+ \\ \\__/".~\\_\\  \\ \\_____\\  \\/\\_____\\  \\ \\_____\\  \\ \\_____\\  \\/\\_____\\
+  \\/_/   \\/_/   \\/_____/   \\/_____/   \\/_____/   \\/_____/   \\/_____/
+=========================================================================================
+    Workflow ran:       : ${workflow.manifest.name}
+    Command ran         : ${workflow.commandLine}
+    Started on          : ${workflow.start}
+    Config File used    : ${workflow.configFiles ?: 'None specified'}
+    Container(s)        : ${workflow.containerEngine}:${workflow.container ?: 'None'}
+    Nextflow Version    : ${workflow.manifest.nextflowVersion}
+    """.stripIndent()
+
+    ////////////////////////////
+    // Start of main workflow //
+    ////////////////////////////
+
+    // channel in all BAMs, parse sample_id as everything before the first dot
+    Channel
+        .fromPath([
+            "${params.bam_dir}/*.bam",
+            "${params.bam_dir}/**/*.bam"
+        ])
+        .map { bam ->
+            def sample_id = (bam.name =~ /^(.+?)\./)[0][1]
+            def bai = file("${bam}.bai").exists() ?
+                      file("${bam}.bai") :
+                      file("${bam.toString().replace('.bam', '.bai')}").exists() ?
+                      file("${bam.toString().replace('.bam', '.bai')}") :
+                      []
+            tuple(sample_id, bam, bai)
+        }
+        .set { all_bams }
+
+    // extract per-sample fingerprint VCFs
+    EXTRACT_FINGERPRINT(all_bams)
+
+    // run all-vs-all crosscheck across all fingerprint VCFs
+    CROSSCHECK_FINGERPRINTS(EXTRACT_FINGERPRINT.out.vcf.collect())
+}

--- a/nextflow_automation/fingerprint/modules/crosscheck_fingerprints.nf
+++ b/nextflow_automation/fingerprint/modules/crosscheck_fingerprints.nf
@@ -1,0 +1,33 @@
+/*
+crosscheck_fingerprints.nf module
+
+This module takes all per-sample fingerprint VCFs and runs Picard's
+CrosscheckFingerprints tool to perform an all-vs-all sample identity check.
+
+Picard version: 3.4.0
+*/
+
+process CROSSCHECK_FINGERPRINTS {
+    label 'lowCpu'
+    label 'medMem'
+    label 'shortTime'
+    stageInMode 'symlink'
+
+    publishDir "${params.output_dir}", mode: 'copy'
+
+    input:
+    path(vcfs)
+
+    output:
+    path("crosscheck.metrics"), emit: metrics
+
+    script:
+    def inputs = vcfs instanceof List ? vcfs.collect { "-I ${it}" }.join(" \\\n        ") : "-I ${vcfs}"
+    """
+    java -jar /usr/picard/picard.jar CrosscheckFingerprints \\
+        ${inputs} \\
+        -H /references/${params.haplotype_map} \\
+        -O crosscheck.metrics \\
+        --CROSSCHECK_BY SAMPLE
+    """
+}

--- a/nextflow_automation/fingerprint/modules/extract_fingerprint.nf
+++ b/nextflow_automation/fingerprint/modules/extract_fingerprint.nf
@@ -1,0 +1,32 @@
+/*
+extract_fingerprint.nf module
+
+This module takes an analysis-ready BAM file and runs Picard's
+ExtractFingerprint tool to produce a per-sample fingerprint VCF.
+
+Picard version: 3.4.0
+*/
+
+process EXTRACT_FINGERPRINT {
+    tag "${sample_id}"
+    label 'lowCpu'
+    label 'medMem'
+    label 'shortTime'
+    stageInMode 'copy'    // copy BAMs from bam_dir into work dir
+
+    publishDir "${params.output_dir}/fingerprints", mode: 'copy'
+
+    input:
+    tuple val(sample_id), path(bam), path(bai)
+
+    output:
+    tuple val(sample_id), path("${sample_id}.fingerprint.vcf"), emit: vcf
+
+    script:
+    """
+    java -jar /usr/picard/picard.jar ExtractFingerprint \\
+        -I ${bam} \\
+        -H /references/${params.haplotype_map} \\
+        -O ${sample_id}.fingerprint.vcf
+    """
+}

--- a/nextflow_automation/fingerprint/nextflow.config
+++ b/nextflow_automation/fingerprint/nextflow.config
@@ -1,0 +1,56 @@
+nextflow.enable.dsl=2
+
+// create parameters (can be altered via command line)
+params {
+    bam_dir = null
+    output_dir = null
+    ref_dir = null
+    haplotype_map = null
+    metadata = null
+    cpus = 1
+    help = false
+}
+
+manifest {
+    name = 'WESley-fingerprint'
+    description = 'GATK Picard fingerprinting to verify sample identity'
+    nextflowVersion = '>=25.04.6'
+    author = 'Dien Ethan Mach'
+    mainScript = 'fingerprint.nf'
+    homePage = 'https://github.com/e10m/WESley'
+}
+
+process {
+    container = 'broadinstitute/picard:3.4.0'
+    containerOptions = "-v ${params.ref_dir}:/references"
+    errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'ignore' }
+    maxRetries = 2
+
+    // CPU labels (static - CPUs don't scale with retries)
+    withLabel: 'highCpu' { cpus = params.cpus }
+    withLabel: 'medCpu' { cpus = 8 }
+    withLabel: 'lowCpu' { cpus = 1 }
+
+    // Memory labels (dynamic - 50% increase per retry)
+    withLabel: 'extraHighMem' { memory = { 64.GB * ((task.attempt-1) * 0.5) } }
+    withLabel: 'highMem' { memory = { 40.GB * ((task.attempt-1) * 0.5) } }
+    withLabel: 'medMem' { memory = { 12.GB * ((task.attempt-1) * 0.5) } }
+    withLabel: 'lowMem' { memory = { 1.GB * ((task.attempt-1) * 0.5) } }
+
+    // Time labels (dynamic - 50% increase per retry)
+    withLabel: 'longTime' { time = { 48.h * ((task.attempt-1) * 0.5) } }
+    withLabel: 'medTime' { time = { 24.h * ((task.attempt-1) * 0.5) } }
+    withLabel: 'shortTime' { time = { 8.h * ((task.attempt-1) * 0.5) } }
+}
+
+// Profiles for different execution environments
+profiles {
+    local {
+        process.executor = 'local'
+    }
+}
+
+docker {
+    enabled = true
+    runOptions = '-u $(id -u):$(id -g)'
+}


### PR DESCRIPTION
Replace two-tier TCGB/short-ID branching logic, metadata remapping, and optional --metadata param with a single flat channel using /^(.+?)\./ to extract sample_id as everything before the first dot.